### PR TITLE
Add psalm-pure for static factory methods

### DIFF
--- a/src/Aeon/Calendar/Gregorian/BusinessHours/BusinessDays.php
+++ b/src/Aeon/Calendar/Gregorian/BusinessHours/BusinessDays.php
@@ -24,11 +24,17 @@ final class BusinessDays
         $this->businessDays = $businessDays;
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function none() : self
     {
         return new self();
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function wholeWeek(WorkingHours $weekWorkingHours, ?WorkingHours $weekendWorkingHours = null) : self
     {
         return new self(
@@ -42,6 +48,9 @@ final class BusinessDays
         );
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function mondayFriday(LinearWorkingHours $workingHours) : self
     {
         return new self(

--- a/src/Aeon/Calendar/Gregorian/BusinessHours/NonBusinessDays.php
+++ b/src/Aeon/Calendar/Gregorian/BusinessHours/NonBusinessDays.php
@@ -21,6 +21,9 @@ final class NonBusinessDays
         $this->nonBusinessDays = $nonBusinessDays;
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function none() : self
     {
         return new self();


### PR DESCRIPTION
Adds missing `psalm-pure` annotation on static factory methods.

**This PR requires changes from https://github.com/aeon-php/calendar/pull/52**